### PR TITLE
Add UAT environment infrastructure and workflows

### DIFF
--- a/.github/workflows/uat-tf-apply.yml
+++ b/.github/workflows/uat-tf-apply.yml
@@ -3,7 +3,7 @@ name: UAT - Terraform Apply
 on:
   push:
     branches:
-      - uat
+      - dev
     paths:
       - "uat/**"
 

--- a/.github/workflows/uat-tf-apply.yml
+++ b/.github/workflows/uat-tf-apply.yml
@@ -1,0 +1,100 @@
+name: UAT - Terraform Apply
+
+on:
+  push:
+    branches:
+      - uat
+    paths:
+      - "uat/**"
+
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: The Pull Request number
+        required: true
+        type: number
+
+permissions:
+  id-token: write # This is required for requesting the JWT (OIDC)
+  contents: read
+  pull-requests: write
+
+jobs:
+  uat_terraform_apply:
+    environment:
+      name: uat
+    env:
+      tf_version: "1.10.2"
+      tf_dir: "uat"
+    defaults:
+      run:
+        working-directory: ${{ env.tf_dir }}
+
+    runs-on: ubuntu-22.04
+    steps:
+      - id: checkout_latest
+        name: Checkout latest
+        uses: actions/checkout@v4
+      - id: checkout_common_action
+        name: Checkout latest
+        uses: actions/checkout@v4
+        with:
+          repository: Innovate-Future-Foundation/terraform-bootstrap
+          path: common
+
+      - id: get_pr_number
+        name: Get PR number
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "Getting PR number based on head_commit"
+            PR_NUMBER=$(gh pr list --base main --state merged --search "${{ github.event.head_commit.message }}" --json number --jq '.[0].number')
+          else
+            echo "Getting PR number from dispatch input"
+            PR_NUMBER=${{ github.event.inputs.pr_number }}
+          fi
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No matching PR found"
+            exit 1
+          fi
+          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: tf_prep
+        name: Terraform setup using oidc role
+        uses: ./common/actions/setup_with_oidc
+        env:
+          aws_tfstate_key: "uat/terraform.tfstate"
+        with:
+          aws_region: ${{ secrets.TF_FRONTEND_REGION }}
+          terraform_dir: ${{ env.tf_dir }}
+          terraform_version: ${{ env.tf_version }}
+          aws_role_arn: "arn:aws:iam::${{ secrets.AWS_UAT_ACCOUNT }}:role/oidc-${{ vars.REPO_ORG_ABBR }}-${{ github.event.repository.name }}"
+          aws_tfstate_bucket: ${{ secrets.TF_FRONTEND_STATE_BUCKET }}
+          aws_tfstate_key: ${{ env.aws_tfstate_key }}
+          aws_tflock_table: ${{ secrets.TF_FRONTEND_LOCKID_TABLE }}
+
+      - id: dl_tf_plan
+        if: steps.get_pr_number.outputs.PR_NUMBER != 0
+        name: Download Plan from S3
+        run: |
+          aws s3 cp s3://${{ secrets.WORKFLOW_TEMP_BUCKET }}/plans/plan-${{ steps.get_pr_number.outputs.PR_NUMBER }}_${{ env.tf_dir }} tfplan
+          if [ $? -ne 0 ]; then
+            echo "Failed to retrieve planfile. It may have expired or been deleted."
+            exit 1
+          fi
+
+      - id: tf_apply_tfplan
+        if: steps.get_pr_number.outputs.PR_NUMBER != 0
+        name: Terraform Apply tfplan
+        run: terraform apply -auto-approve tfplan
+
+      - id: tf_hot_apply
+        if: steps.get_pr_number.outputs.PR_NUMBER == 0
+        name: Terraform Fast Apply For Hotfix
+        run: terraform apply -auto-approve
+        env:
+          TF_VAR_location: ${{ secrets.AWS_REGION }}
+          TF_VAR_dev_account: ${{ secrets.AWS_DEV_ACCOUNT }}
+          TF_VAR_staging_account: ${{ secrets.AWS_STAGING_ACCOUNT }}
+          TF_VAR_prod_account: ${{ secrets.AWS_PROD_ACCOUNT }}

--- a/.github/workflows/uat-tf-apply.yml
+++ b/.github/workflows/uat-tf-apply.yml
@@ -22,9 +22,8 @@ permissions:
 jobs:
   uat_terraform_apply:
     environment:
-      name: uat
+      name: UAT
     env:
-      tf_version: "1.10.2"
       tf_dir: "uat"
     defaults:
       run:
@@ -35,66 +34,35 @@ jobs:
       - id: checkout_latest
         name: Checkout latest
         uses: actions/checkout@v4
-      - id: checkout_common_action
-        name: Checkout latest
-        uses: actions/checkout@v4
+
+      - id: extract_pr_info
+        name: Extract PR Info
+        uses: Innovate-Future-Foundation/common-action/extract-pr-info@main
         with:
-          repository: Innovate-Future-Foundation/terraform-bootstrap
-          path: common
-
-      - id: get_pr_number
-        name: Get PR number
-        run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
-            echo "Getting PR number based on head_commit"
-            PR_NUMBER=$(gh pr list --base main --state merged --search "${{ github.event.head_commit.message }}" --json number --jq '.[0].number')
-          else
-            echo "Getting PR number from dispatch input"
-            PR_NUMBER=${{ github.event.inputs.pr_number }}
-          fi
-          if [ -z "$PR_NUMBER" ]; then
-            echo "No matching PR found"
-            exit 1
-          fi
-          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+          github_token: ${{ github.token }}
+          pr_number: ${{ inputs.pr_number }}
+  
       - id: tf_prep
         name: Terraform setup using oidc role
-        uses: ./common/actions/setup_with_oidc
-        env:
-          aws_tfstate_key: "uat/terraform.tfstate"
+        uses: Innovate-Future-Foundation/common-action/setup-tf-aws@main
         with:
-          aws_region: ${{ secrets.TF_FRONTEND_REGION }}
           terraform_dir: ${{ env.tf_dir }}
-          terraform_version: ${{ env.tf_version }}
-          aws_role_arn: "arn:aws:iam::${{ secrets.AWS_UAT_ACCOUNT }}:role/oidc-${{ vars.REPO_ORG_ABBR }}-${{ github.event.repository.name }}"
-          aws_tfstate_bucket: ${{ secrets.TF_FRONTEND_STATE_BUCKET }}
-          aws_tfstate_key: ${{ env.aws_tfstate_key }}
-          aws_tflock_table: ${{ secrets.TF_FRONTEND_LOCKID_TABLE }}
+          terraform_version: ${{ vars.TF_VERSION }}
+          backend_region: ${{ secrets.TF_BACKEND_REGION }}
+          backend_role_arn: "arn:aws:iam::${{ secrets.AWS_UAT_ACCOUNT }}:role/oidc-${{ vars.REPO_ORG_ABBR }}-${{ github.event.repository.name }}"
+          backend_state_bucket: ${{ secrets.TF_BACKEND_STATE_BUCKET }}
+          backend_lockid_table: ${{ secrets.TF_BACKEND_LOCKID_TABLE }}
 
-      - id: dl_tf_plan
-        if: steps.get_pr_number.outputs.PR_NUMBER != 0
-        name: Download Plan from S3
-        run: |
-          aws s3 cp s3://${{ secrets.WORKFLOW_TEMP_BUCKET }}/plans/plan-${{ steps.get_pr_number.outputs.PR_NUMBER }}_${{ env.tf_dir }} tfplan
-          if [ $? -ne 0 ]; then
-            echo "Failed to retrieve planfile. It may have expired or been deleted."
-            exit 1
-          fi
-
-      - id: tf_apply_tfplan
-        if: steps.get_pr_number.outputs.PR_NUMBER != 0
-        name: Terraform Apply tfplan
-        run: terraform apply -auto-approve tfplan
+      - id: tf_apply_plan
+        name: Terraform apply plan file from s3
+        if: steps.extract_pr_info.outputs.PR_NUMBER != 0
+        uses: Innovate-Future-Foundation/common-action/apply-tfplan-s3@main
+        with:
+          tf_dir: ${{ env.tf_dir }}
+          s3_bucket: ${{ secrets.WORKFLOW_TEMP_BUCKET }}
+          obj_key: "plans/plan-${{ steps.extract_pr_info.outputs.PR_NUMBER }}_${{ env.tf_dir }}"
 
       - id: tf_hot_apply
-        if: steps.get_pr_number.outputs.PR_NUMBER == 0
+        if: steps.extract_pr_info.outputs.PR_NUMBER == 0
         name: Terraform Fast Apply For Hotfix
         run: terraform apply -auto-approve
-        env:
-          TF_VAR_location: ${{ secrets.AWS_REGION }}
-          TF_VAR_dev_account: ${{ secrets.AWS_DEV_ACCOUNT }}
-          TF_VAR_staging_account: ${{ secrets.AWS_STAGING_ACCOUNT }}
-          TF_VAR_prod_account: ${{ secrets.AWS_PROD_ACCOUNT }}

--- a/.github/workflows/uat-tf-plan.yml
+++ b/.github/workflows/uat-tf-plan.yml
@@ -3,7 +3,7 @@ name: UAT - Terraform Plan
 on:
   pull_request:
     branches:
-      - uat
+      - dev
     paths:
       - "uat/**"
       - ".github/workflows/uat-tf-plan.yml"

--- a/.github/workflows/uat-tf-plan.yml
+++ b/.github/workflows/uat-tf-plan.yml
@@ -20,9 +20,8 @@ concurrency:
 jobs:
   uat_terraform_plan:
     environment:
-      name: uat
+      name: UAT
     env:
-      tf_version: "1.10.2"
       tf_dir: "uat"
 
     runs-on: ubuntu-22.04
@@ -36,45 +35,26 @@ jobs:
         name: Checkout latest
         uses: actions/checkout@v4
 
-      - id: checkout_common_action
-        name: Checkout latest
-        uses: actions/checkout@v4
-        with:
-          repository: Innovate-Future-Foundation/terraform-bootstrap
-          path: common
-
       - id: tf_prep
         name: Terraform setup using oidc role
-        uses: ./common/actions/setup_with_oidc
-        env:
-          aws_tfstate_key: "uat/terraform.tfstate"
+        uses: Innovate-Future-Foundation/common-action/setup-tf-aws@main
         with:
-          aws_region: ${{ secrets.TF_FRONTEND_REGION }}
           terraform_dir: ${{ env.tf_dir }}
-          terraform_version: ${{ env.tf_version }}
-          aws_role_arn: "arn:aws:iam::${{ secrets.AWS_UAT_ACCOUNT }}:role/oidc-${{ vars.REPO_ORG_ABBR }}-${{ github.event.repository.name }}"
-          aws_tfstate_bucket: ${{ secrets.TF_FRONTEND_STATE_BUCKET }}
-          aws_tfstate_key: "uat/terraform.tfstate"
-          aws_tflock_table: ${{ secrets.TF_FRONTEND_LOCKID_TABLE }}
+          terraform_version: ${{ vars.TF_VERSION }}
+          backend_region: ${{ secrets.TF_BACKEND_REGION }}
+          backend_role_arn: "arn:aws:iam::${{ secrets.AWS_UAT_ACCOUNT }}:role/oidc-${{ vars.REPO_ORG_ABBR }}-${{ github.event.repository.name }}"
+          backend_state_bucket: ${{ secrets.TF_BACKEND_STATE_BUCKET }}
+          backend_lockid_table: ${{ secrets.TF_BACKEND_LOCKID_TABLE }}
 
       - id: tf_plan
         name: Terraform Plan
         run: terraform plan -out .planfile
-        env:
-          TF_VAR_location: ${{ secrets.AWS_REGION }}
-          TF_VAR_dev_account: ${{ secrets.AWS_DEV_ACCOUNT }}
-          TF_VAR_staging_account: ${{ secrets.AWS_STAGING_ACCOUNT }}
-          TF_VAR_prod_account: ${{ secrets.AWS_PROD_ACCOUNT }}
 
-      - id: post_comment
-        name: Post Terraform Plan to PR
-        uses: borchero/terraform-plan-comment@v2
+      - id: publish_tf_plan
+        name: Publish Plan to PR and S3
+        uses: Innovate-Future-Foundation/common-action/publish-tfplan-s3@main
         with:
-          working-directory: ${{ env.tf_dir }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          planfile: .planfile
-
-      - name: Upload Plan to S3
-        run: |
-          aws s3 cp .planfile s3://inff-frontend-infrastructure-workflow-temp-melj2/plans/plan-${{ github.event.pull_request.number }}_${{ env.tf_dir }}
-          echo "Plan uploaded to S3"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tf_dir: ${{ env.tf_dir }}
+          s3_bucket: ${{ secrets.WORKFLOW_TEMP_BUCKET }}
+          obj_key: plans/plan-${{ github.event.pull_request.number }}_${{ env.tf_dir }}

--- a/.github/workflows/uat-tf-plan.yml
+++ b/.github/workflows/uat-tf-plan.yml
@@ -1,0 +1,80 @@
+name: UAT - Terraform Plan
+
+on:
+  pull_request:
+    branches:
+      - uat
+    paths:
+      - "uat/**"
+      - ".github/workflows/uat-tf-plan.yml"
+
+permissions:
+  id-token: write # This is required for requesting the JWT (OIDC)
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  uat_terraform_plan:
+    environment:
+      name: uat
+    env:
+      tf_version: "1.10.2"
+      tf_dir: "uat"
+
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: ./uat
+
+    if: github.event.pull_request.state != 'approved'
+    steps:
+      - id: checkout_latest
+        name: Checkout latest
+        uses: actions/checkout@v4
+
+      - id: checkout_common_action
+        name: Checkout latest
+        uses: actions/checkout@v4
+        with:
+          repository: Innovate-Future-Foundation/terraform-bootstrap
+          path: common
+
+      - id: tf_prep
+        name: Terraform setup using oidc role
+        uses: ./common/actions/setup_with_oidc
+        env:
+          aws_tfstate_key: "uat/terraform.tfstate"
+        with:
+          aws_region: ${{ secrets.TF_FRONTEND_REGION }}
+          terraform_dir: ${{ env.tf_dir }}
+          terraform_version: ${{ env.tf_version }}
+          aws_role_arn: "arn:aws:iam::${{ secrets.AWS_UAT_ACCOUNT }}:role/oidc-${{ vars.REPO_ORG_ABBR }}-${{ github.event.repository.name }}"
+          aws_tfstate_bucket: ${{ secrets.TF_FRONTEND_STATE_BUCKET }}
+          aws_tfstate_key: "uat/terraform.tfstate"
+          aws_tflock_table: ${{ secrets.TF_FRONTEND_LOCKID_TABLE }}
+
+      - id: tf_plan
+        name: Terraform Plan
+        run: terraform plan -out .planfile
+        env:
+          TF_VAR_location: ${{ secrets.AWS_REGION }}
+          TF_VAR_dev_account: ${{ secrets.AWS_DEV_ACCOUNT }}
+          TF_VAR_staging_account: ${{ secrets.AWS_STAGING_ACCOUNT }}
+          TF_VAR_prod_account: ${{ secrets.AWS_PROD_ACCOUNT }}
+
+      - id: post_comment
+        name: Post Terraform Plan to PR
+        uses: borchero/terraform-plan-comment@v2
+        with:
+          working-directory: ${{ env.tf_dir }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          planfile: .planfile
+
+      - name: Upload Plan to S3
+        run: |
+          aws s3 cp .planfile s3://inff-frontend-infrastructure-workflow-temp-melj2/plans/plan-${{ github.event.pull_request.number }}_${{ env.tf_dir }}
+          echo "Plan uploaded to S3"

--- a/uat/backend.tf
+++ b/uat/backend.tf
@@ -1,5 +1,4 @@
 terraform {
-  backend "local" {
-    # Using local backend for testing
+  backend "s3" {
   }
 }

--- a/uat/backend.tf
+++ b/uat/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "local" {
+    # Using local backend for testing
+  }
+}

--- a/uat/cloudfront/main.tf
+++ b/uat/cloudfront/main.tf
@@ -1,0 +1,77 @@
+data "aws_cloudfront_cache_policy" "optimized" {
+  name = "Managed-CachingOptimized"
+}
+
+data "aws_cloudfront_response_headers_policy" "security_headers" {
+  name = "Managed-SecurityHeadersPolicy"
+}
+
+resource "aws_cloudfront_origin_access_control" "frontend" {
+  name                              = "${var.domain_name}-oac"
+  description                       = "Origin Access Control for frontend static website"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_distribution" "frontend" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  default_root_object = "index.html"
+  price_class         = "PriceClass_All"
+
+  origin {
+    domain_name              = var.bucket_domain_name
+    origin_id                = local.s3_origin_id
+    origin_access_control_id = aws_cloudfront_origin_access_control.frontend.id
+  }
+
+  default_cache_behavior {
+    allowed_methods            = ["GET", "HEAD", "OPTIONS"]
+    cached_methods             = ["GET", "HEAD"]
+    target_origin_id           = local.s3_origin_id
+    viewer_protocol_policy     = "redirect-to-https"
+    response_headers_policy_id = data.aws_cloudfront_response_headers_policy.security_headers.id
+    cache_policy_id            = data.aws_cloudfront_cache_policy.optimized.id
+    compress                   = true
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = var.use_acm_certificate ? var.acm_certificate_arn : null
+    ssl_support_method       = var.use_acm_certificate ? "sni-only" : null
+    minimum_protocol_version = var.use_acm_certificate ? "TLSv1.2_2021" : "TLSv1"
+    cloudfront_default_certificate = var.use_acm_certificate ? false : true
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  aliases = var.use_acm_certificate ? [var.domain_name] : []
+
+  custom_error_response {
+    error_code         = 403
+    response_code      = 200
+    response_page_path = "/index.html"
+  }
+
+  custom_error_response {
+    error_code         = 404
+    response_code      = 200
+    response_page_path = "/index.html"
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Name    = "${var.domain_name}-distribution"
+      Service = "Content Delivery"
+    }
+  )
+}
+
+locals {
+  s3_origin_id = "S3-${var.domain_name}"
+}

--- a/uat/cloudfront/outputs.tf
+++ b/uat/cloudfront/outputs.tf
@@ -1,0 +1,19 @@
+output "distribution_id" {
+  value = aws_cloudfront_distribution.frontend.id
+}
+
+output "distribution_domain_name" {
+  value = aws_cloudfront_distribution.frontend.domain_name
+}
+
+output "distribution_hosted_zone_id" {
+  value = aws_cloudfront_distribution.frontend.hosted_zone_id
+}
+
+output "distribution_arn" {
+  value = aws_cloudfront_distribution.frontend.arn
+}
+
+output "origin_access_control_id" {
+  value = aws_cloudfront_origin_access_control.frontend.id
+}

--- a/uat/cloudfront/variables.tf
+++ b/uat/cloudfront/variables.tf
@@ -1,0 +1,36 @@
+variable "domain_name" {
+  type        = string
+  description = "Domain name for the CloudFront distribution"
+}
+
+variable "bucket_domain_name" {
+  type        = string
+  description = "Domain name of the S3 bucket"
+}
+
+variable "bucket_arn" {
+  type        = string
+  description = "ARN of the S3 bucket"
+}
+
+variable "acm_certificate_arn" {
+  type        = string
+  description = "ARN of the ACM certificate"
+}
+
+variable "environment" {
+  type        = string
+  description = "Environment name (e.g., dev, prod)"
+  default     = "dev"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Resource tags"
+}
+
+variable "use_acm_certificate" {
+  description = "Whether to use an ACM certificate"
+  type        = bool
+  default     = true
+}

--- a/uat/main.tf
+++ b/uat/main.tf
@@ -1,0 +1,38 @@
+locals {
+  bucket_name = "${var.environment}-${var.bucket_name}"
+}
+
+module "s3" {
+  source = "./s3"
+
+  bucket_name                 = local.bucket_name
+  environment                 = var.environment
+  cloudfront_distribution_arn = module.cloudfront.distribution_arn
+  tags                        = var.tags
+
+}
+
+module "cloudfront" {
+  source = "./cloudfront"
+
+  domain_name         = var.domain_name
+  bucket_domain_name  = module.s3.bucket_domain_name
+  bucket_arn          = module.s3.bucket_arn
+  acm_certificate_arn = module.route53_acm.certificate_arn
+  environment         = var.environment
+  tags                = var.tags
+  use_acm_certificate = false
+}
+
+module "route53_acm" {
+  source = "./route53_acm"
+  providers = {
+    aws.us-east-1 = aws.us-east-1
+  }
+
+  domain_name            = var.domain_name
+  cloudfront_domain_name = module.cloudfront.distribution_domain_name
+  cloudfront_zone_id     = module.cloudfront.distribution_hosted_zone_id
+  tags                   = var.tags
+  create_route53_records = false
+}

--- a/uat/outputs.tf
+++ b/uat/outputs.tf
@@ -1,0 +1,24 @@
+output "s3_bucket" {
+  description = "The name of the S3 bucket hosting the static website"
+  value       = module.s3.bucket_name
+}
+
+output "cloudfront_distribution_url" {
+  description = "The domain name of the CloudFront distribution"
+  value       = module.cloudfront.distribution_domain_name
+}
+
+output "cloudfront_distribution_id" {
+  description = "The ID of the CloudFront distribution"
+  value       = module.cloudfront.distribution_id
+}
+
+output "website_domain" {
+  description = "The domain name of the website"
+  value       = var.domain_name
+}
+
+output "acm_certificate_arn" {
+  description = "The ARN of the ACM certificate"
+  value       = module.route53_acm.certificate_arn
+}

--- a/uat/provider.tf
+++ b/uat/provider.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = var.tags
+  }
+}
+
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+}

--- a/uat/route53_acm/main.tf
+++ b/uat/route53_acm/main.tf
@@ -1,0 +1,55 @@
+data "aws_route53_zone" "domain" {
+  count        = var.create_route53_records ? 1 : 0
+  name         = var.domain_name
+  private_zone = false
+}
+
+resource "aws_acm_certificate" "frontend" {
+  provider          = aws.us-east-1
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+
+  tags = merge(
+    var.tags,
+    {
+      Name    = "${var.domain_name}-certificate"
+      Service = "SSL Certificate"
+    }
+  )
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+locals {
+  domain_validation_options = var.create_route53_records ? aws_acm_certificate.frontend.domain_validation_options : []
+}
+
+resource "aws_route53_record" "acm_validation" {
+  count   = var.create_route53_records ? length(local.domain_validation_options) : 0
+  zone_id = data.aws_route53_zone.domain[0].zone_id
+  name    = element(local.domain_validation_options, count.index).resource_record_name
+  type    = element(local.domain_validation_options, count.index).resource_record_type
+  records = [element(local.domain_validation_options, count.index).resource_record_value]
+  ttl     = 60
+}
+
+resource "aws_acm_certificate_validation" "frontend" {
+  count                   = var.create_route53_records ? 1 : 0
+  provider                = aws.us-east-1
+  certificate_arn         = aws_acm_certificate.frontend.arn
+  validation_record_fqdns = var.create_route53_records ? aws_route53_record.acm_validation[*].fqdn : []
+}
+
+resource "aws_route53_record" "frontend" {
+  count   = var.create_route53_records ? 1 : 0
+  zone_id = data.aws_route53_zone.domain[0].zone_id
+  name    = var.domain_name
+  type    = "A"
+
+  alias {
+    name                   = var.cloudfront_domain_name
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/uat/route53_acm/outputs.tf
+++ b/uat/route53_acm/outputs.tf
@@ -1,0 +1,7 @@
+output "certificate_arn" {
+  value = aws_acm_certificate.frontend.arn
+}
+
+output "domain_zone_id" {
+  value = var.create_route53_records ? data.aws_route53_zone.domain[0].zone_id : ""
+}

--- a/uat/route53_acm/provider.tf
+++ b/uat/route53_acm/provider.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = "~> 5.0"
+      configuration_aliases = [aws.us-east-1]
+    }
+  }
+}

--- a/uat/route53_acm/variables.tf
+++ b/uat/route53_acm/variables.tf
@@ -1,0 +1,25 @@
+variable "domain_name" {
+  type        = string
+  description = "Domain name for the frontend application"
+}
+
+variable "cloudfront_domain_name" {
+  type        = string
+  description = "CloudFront distribution domain name"
+}
+
+variable "cloudfront_zone_id" {
+  type        = string
+  description = "CloudFront distribution hosted zone ID"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Resource tags"
+}
+
+variable "create_route53_records" {
+  description = "Whether to create Route 53 records"
+  type        = bool
+  default     = true
+}

--- a/uat/s3/main.tf
+++ b/uat/s3/main.tf
@@ -1,0 +1,36 @@
+resource "aws_s3_bucket" "frontend" {
+  bucket = var.bucket_name
+
+  tags = merge(
+    var.tags,
+    {
+      Name    = "${var.bucket_name}-frontend-bucket"
+      Service = "Static Website Hosting"
+    }
+  )
+}
+
+resource "aws_s3_bucket_public_access_block" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_versioning" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}

--- a/uat/s3/outputs.tf
+++ b/uat/s3/outputs.tf
@@ -1,0 +1,11 @@
+output "bucket_name" {
+  value = aws_s3_bucket.frontend.id
+}
+
+output "bucket_arn" {
+  value = aws_s3_bucket.frontend.arn
+}
+
+output "bucket_domain_name" {
+  value = aws_s3_bucket.frontend.bucket_regional_domain_name
+}

--- a/uat/s3/policies.tf
+++ b/uat/s3/policies.tf
@@ -1,0 +1,22 @@
+data "aws_iam_policy_document" "frontend_s3_policy" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.frontend.arn}/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [var.cloudfront_distribution_arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "frontend" {
+  bucket = aws_s3_bucket.frontend.id
+  policy = data.aws_iam_policy_document.frontend_s3_policy.json
+}

--- a/uat/s3/variables.tf
+++ b/uat/s3/variables.tf
@@ -1,0 +1,19 @@
+variable "bucket_name" {
+  type        = string
+  description = "Name of the S3 bucket for frontend static files"
+}
+
+variable "environment" {
+  type        = string
+  description = "Environment name"
+}
+
+variable "cloudfront_distribution_arn" {
+  type        = string
+  description = "The ARN of the CloudFront distribution"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Resource tags"
+}

--- a/uat/terraform.tfvars
+++ b/uat/terraform.tfvars
@@ -1,4 +1,4 @@
 region      = "ap-southeast-2"
 environment = "uat"
 bucket_name = "foundation-innovatefuture-uat-frontend-static"
-domain_name = "uat.innovatefuture.foundation" 
+domain_name = "uat01.innovatefuture.foundation"

--- a/uat/terraform.tfvars
+++ b/uat/terraform.tfvars
@@ -1,0 +1,4 @@
+region      = "ap-southeast-2"
+environment = "uat"
+bucket_name = "foundation-innovatefuture-uat-frontend-static"
+domain_name = "uat.innovatefuture.foundation" 

--- a/uat/variables.tf
+++ b/uat/variables.tf
@@ -1,0 +1,36 @@
+variable "region" {
+  type        = string
+  description = "AWS region"
+  default     = "ap-southeast-2"
+}
+
+variable "environment" {
+  type        = string
+  description = "Environment name"
+  default     = "uat"
+}
+
+variable "bucket_name" {
+  type        = string
+  description = "Name of the S3 bucket for frontend static files"
+}
+
+variable "domain_name" {
+  type        = string
+  description = "Domain name for the frontend application"
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9.-]*[a-z0-9]$", var.domain_name))
+    error_message = "Domain name must be a valid domain name."
+  }
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Common tags for all resources"
+  default = {
+    Environment = "uat"
+    ManagedBy   = "Terraform"
+    Project     = "IFF"
+    Owner       = "IFA"
+  }
+}


### PR DESCRIPTION
## Overview
This pull request adds the necessary infrastructure as code (IaC) for the UAT environment using Terraform. It includes all the required AWS resources and GitHub Actions workflows for automated deployment.

## Changes
- Added UAT Terraform configuration for:
  - S3 bucket for static website hosting
  - CloudFront distribution for content delivery
  - ACM certificate for HTTPS (configured for optional use)
  - Route53 ACM module with conditional creation of DNS records

- Added GitHub Actions workflows:
  - `uat-tf-plan.yml`: Runs Terraform plan on pull requests to the UAT branch
  - `uat-tf-apply.yml`: Applies Terraform changes when code is merged to the UAT branch

## Testing
The UAT environment has been tested locally with:
- Successfully created S3 bucket: `uat-foundation-innovatefuture-uat-frontend-static`
- Successfully created CloudFront distribution with default certificate
- Successfully deployed test content to verify the infrastructure
